### PR TITLE
Add WatsonX inference support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+

--- a/lcb_runner/evaluation/compute_code_execution_metrics.py
+++ b/lcb_runner/evaluation/compute_code_execution_metrics.py
@@ -1,8 +1,11 @@
 import numpy as np
 from concurrent.futures import ProcessPoolExecutor
-import tqdm
+import os
+import requests
+import json
 
 from lcb_runner.evaluation.utils_execute import BASE_IMPORTS, check_correctness
+
 
 def evaluate_score(args) -> list[bool]:
     gs, (c, i, o) = args
@@ -11,6 +14,10 @@ def evaluate_score(args) -> list[bool]:
     for g in gs:
         if i in g:
             pass
+        elif url := os.getenv("WX_URL_ADDR"):
+            code_to_execute = f"{BASE_IMPORTS}\n{c}\nassert {o} == {g}\n"
+            status = send_code_exec_request(code=code_to_execute, url=url)
+            execution_results.append(True if status["exit_code"] == 0 else False)
         else:
             code_to_execute = f"{BASE_IMPORTS}\n{c}\nassert {o} == {g}"
             execution_results.append(check_correctness(code_to_execute, 3))
@@ -18,9 +25,12 @@ def evaluate_score(args) -> list[bool]:
         execution_results = [False] * len(gs)
     return execution_results
 
+
 def pass_at_k(n, c, k):
-    if n - c < k: return 1.0
+    if n - c < k:
+        return 1.0
     return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
+
 
 def code_execution_metrics(
     samples,
@@ -54,3 +64,28 @@ def code_execution_metrics(
             r_new.append([_r])
         results[i] = r_new
     return [metrics, results]
+
+
+def send_code_exec_request(code: str, url: str) -> dict:
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    response = requests.post(
+        url=url,
+        headers=headers,
+        json={
+            "lang": "python",
+            "code": code,
+        },
+    )
+
+    if not response.ok or response.status_code >= 300:
+        raise Exception(f"Problem with the server, please check if url is valid: {url}")
+
+    status = json.loads(response.content.decode("utf-8"))
+    if isinstance(status, list):
+        status = status[0]
+
+    return status

--- a/lcb_runner/evaluation/testing_util.py
+++ b/lcb_runner/evaluation/testing_util.py
@@ -1,8 +1,10 @@
 import ast
+import os
 import json
 import sys
 import faulthandler
 import platform
+import requests
 
 # used for debugging to time steps
 from datetime import datetime
@@ -431,6 +433,21 @@ def run_test(sample, test=None, debug=False, timeout=6):
             print(f"loading test code = {datetime.now().time()}")
 
         if which_type == CODE_TYPE.call_based:
+            if url := os.getenv("WX_URL_ADDR"):
+                try:
+                    status = send_code_exec_request(
+                        code=test,
+                        url=url,
+                        in_outs=in_outs,
+                        fn_name=method_name,
+                        timeout=timeout * 2,
+                    )
+                    return status["all_results"], status["metadata"]
+                except Exception as e:
+                    return [-4], {
+                        "error_code": -4,
+                        "error_message": f"Error during testing: {e}",
+                    }
             signal.alarm(timeout)
             try:
                 results, metadata = grade_call_based(
@@ -451,7 +468,18 @@ def run_test(sample, test=None, debug=False, timeout=6):
         elif which_type == CODE_TYPE.standard_input:
             # sol
             # if code has if __name__ == "__main__": then remove it
+            if url := os.getenv("WX_URL_ADDR"):
+                try:
+                    status = send_code_exec_request(
+                        code=test, url=url, in_outs=in_outs, timeout=timeout * 2
+                    )
 
+                    return status["all_results"], status["metadata"]
+                except Exception as e:
+                    return [-4], {
+                        "error_code": -4,
+                        "error_message": f"Error during testing: {e}",
+                    }
             signal.alarm(timeout)
             try:
                 results, metadata = grade_stdio(
@@ -554,3 +582,38 @@ def reliability_guard(maximum_memory_bytes=None):
     sys.modules["resource"] = None
     sys.modules["psutil"] = None
     sys.modules["tkinter"] = None
+
+
+def send_code_exec_request(
+    code: str, url: str, in_outs: dict, fn_name: str = None, timeout: int = 10
+) -> dict:
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    response = requests.get(
+        url=url.replace("/evaluate_code", "/health"),
+    )
+    if response.status_code != 200:
+        time.sleep(10)
+
+    response = requests.post(
+        url=url,
+        headers=headers,
+        json={
+            "lang": "python",
+            "code": code,
+            "user_data": in_outs,
+            "fn_name": fn_name,
+        },
+        timeout=timeout,
+    )
+
+    if not response.ok or response.status_code >= 300:
+        raise Exception(f"Problem with the response from server, check url: {url}")
+
+    status = json.loads(response.content.decode("utf-8"))
+    if isinstance(status, list):
+        status = status[0]
+
+    return status

--- a/lcb_runner/lm_styles.py
+++ b/lcb_runner/lm_styles.py
@@ -701,6 +701,13 @@ LanguageModelList: list[LanguageModel] = [
         link="https://huggingface.co/ibm-granite/granite-3.1-8b-instruct",
     ),
     LanguageModel(
+        "ibm/granite-3-3-8b-instruct",
+        "Granite-3.3-8B-Instruct",
+        LMStyle.WxGranite,
+        datetime(2025, 4, 16),
+        link="https://huggingface.co/ibm-granite/granite-3.3-8b-instruct",
+    ),
+    LanguageModel(
         "meta-llama/llama-3-2-3b-instruct",
         "LLama3.2-3b-Ins",
         LMStyle.WxLLaMa,
@@ -713,6 +720,27 @@ LanguageModelList: list[LanguageModel] = [
         LMStyle.WxLLaMa,
         datetime(2024, 7, 23),
         link="https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
+    ),
+    LanguageModel(
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+        "Llama-4-Scout-17B-16E-Instruct",
+        LMStyle.WxLLaMa,
+        datetime(2025, 4, 7),
+        link="https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
+    ),
+    LanguageModel(
+        "meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
+        "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        LMStyle.WxLLaMa,
+        datetime(2025, 4, 7),
+        link="https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+    ),
+    LanguageModel(
+        "mistralai/mistral-medium-2505",
+        "Mistral-medium-2505",
+        LMStyle.WxMistral,
+        datetime(2025, 5, 7),
+        link="https://mistral.ai/news/mistral-medium-3",
     ),
 ]
 

--- a/lcb_runner/lm_styles.py
+++ b/lcb_runner/lm_styles.py
@@ -30,6 +30,8 @@ class LMStyle(Enum):
 
     DeepSeekR1 = "DeepSeekR1"
 
+    Watsonx = "Watsonx"
+
 
 @dataclass
 class LanguageModel:
@@ -646,6 +648,69 @@ LanguageModelList: list[LanguageModel] = [
         LMStyle.DeepSeekR1,
         datetime(2025, 1, 20),
         link="https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    ),
+    LanguageModel(
+        "ibm/granite-3b-code-instruct",
+        "Granite-3B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 5, 9),
+        link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-3b-code-instruct-model-card",
+    ),
+    LanguageModel(
+        "ibm/granite-8b-code-instruct",
+        "Granite-8B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 7, 18),
+        link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-8b-code-instruct-model-card",
+    ),
+    LanguageModel(
+        "ibm/granite-20b-code-instruct",
+        "Granite-20B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 5, 6),
+        link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-20b-code-instruct-model-card",
+    ),
+    LanguageModel(
+        "ibm/granite-34b-code-instruct",
+        "Granite-34B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 5, 6),
+        link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-34b-code-instruct-model-card",
+    ),
+    LanguageModel(
+        "mistralai/mixtral-8x7b-instruct-v01",
+        "Mixtral-8x7B-Instruct-v0.1",
+        LMStyle.Watsonx,
+        datetime(2023, 1, 1),
+        link="https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1",
+    ),
+    LanguageModel(
+        "ibm/granite-3-2b-instruct",
+        "Granite-3-2B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 12, 18),
+        link="https://huggingface.co/ibm-granite/granite-3.1-2b-instruct",
+    ),
+    LanguageModel(
+        "ibm/granite-3-8b-instruct",
+        "Granite-3-8B-Code-Instruct",
+        LMStyle.Watsonx,
+        datetime(2024, 12, 18),
+        link="https://huggingface.co/ibm-granite/granite-3.1-8b-instruct",
+    ),
+    LanguageModel(
+        "meta-llama/llama-3-2-3b-instruct",
+        "LLama3.2-3b-Ins",
+        LMStyle.Watsonx,
+        datetime(2024, 7, 25),
+        link="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
+    ),
+    LanguageModel(
+        "meta-llama/llama-3-1-8b-instruct",
+        "LLama3.1-8b-Ins",
+        LMStyle.Watsonx,
+        datetime(2024, 7, 23),
+        link="https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
     ),
 ]
 

--- a/lcb_runner/lm_styles.py
+++ b/lcb_runner/lm_styles.py
@@ -30,7 +30,9 @@ class LMStyle(Enum):
 
     DeepSeekR1 = "DeepSeekR1"
 
-    Watsonx = "Watsonx"
+    WxGranite = "WxGranite"
+    WxLLaMa = "WxLLaMa"
+    WxMistral = "WxMistral"
 
 
 @dataclass
@@ -652,63 +654,63 @@ LanguageModelList: list[LanguageModel] = [
     LanguageModel(
         "ibm/granite-3b-code-instruct",
         "Granite-3B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 5, 9),
         link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-3b-code-instruct-model-card",
     ),
     LanguageModel(
         "ibm/granite-8b-code-instruct",
         "Granite-8B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 7, 18),
         link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-8b-code-instruct-model-card",
     ),
     LanguageModel(
         "ibm/granite-20b-code-instruct",
         "Granite-20B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 5, 6),
         link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-20b-code-instruct-model-card",
     ),
     LanguageModel(
         "ibm/granite-34b-code-instruct",
         "Granite-34B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 5, 6),
         link="https://www.ibm.com/docs/en/watsonx/w-and-w/2.0.x?topic=models-granite-34b-code-instruct-model-card",
     ),
     LanguageModel(
         "mistralai/mixtral-8x7b-instruct-v01",
         "Mixtral-8x7B-Instruct-v0.1",
-        LMStyle.Watsonx,
+        LMStyle.WxMistral,
         datetime(2023, 1, 1),
         link="https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1",
     ),
     LanguageModel(
         "ibm/granite-3-2b-instruct",
         "Granite-3-2B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 12, 18),
         link="https://huggingface.co/ibm-granite/granite-3.1-2b-instruct",
     ),
     LanguageModel(
         "ibm/granite-3-8b-instruct",
         "Granite-3-8B-Code-Instruct",
-        LMStyle.Watsonx,
+        LMStyle.WxGranite,
         datetime(2024, 12, 18),
         link="https://huggingface.co/ibm-granite/granite-3.1-8b-instruct",
     ),
     LanguageModel(
         "meta-llama/llama-3-2-3b-instruct",
         "LLama3.2-3b-Ins",
-        LMStyle.Watsonx,
+        LMStyle.WxLLaMa,
         datetime(2024, 7, 25),
         link="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct",
     ),
     LanguageModel(
         "meta-llama/llama-3-1-8b-instruct",
         "LLama3.1-8b-Ins",
-        LMStyle.Watsonx,
+        LMStyle.WxLLaMa,
         datetime(2024, 7, 23),
         link="https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct",
     ),

--- a/lcb_runner/prompts/code_execution.py
+++ b/lcb_runner/prompts/code_execution.py
@@ -136,6 +136,8 @@ def format_prompt_execution_base(
         return prompt
     elif LanguageModelStyle == LMStyle.CodeLLaMaInstruct:
         return prompt
+    elif LanguageModelStyle == LMStyle.Watsonx:
+        return prompt
     elif LanguageModelStyle == LMStyle.MagiCoder:
         return prompt
     elif LanguageModelStyle == LMStyle.WizardCoder:

--- a/lcb_runner/prompts/code_execution.py
+++ b/lcb_runner/prompts/code_execution.py
@@ -136,7 +136,11 @@ def format_prompt_execution_base(
         return prompt
     elif LanguageModelStyle == LMStyle.CodeLLaMaInstruct:
         return prompt
-    elif LanguageModelStyle == LMStyle.Watsonx:
+    elif LanguageModelStyle == LMStyle.WxGranite:
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxLLaMa:
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxMistral:
         return prompt
     elif LanguageModelStyle == LMStyle.MagiCoder:
         return prompt

--- a/lcb_runner/prompts/code_generation.py
+++ b/lcb_runner/prompts/code_generation.py
@@ -29,7 +29,9 @@ class PromptConstants:
         "The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. "
         "The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think> <answer> answer here </answer>.<｜User｜>"
     )
+
     SYSTEM_MESSAGE_GRANITE = """You are an intelligent AI programming assistant, utilizing a Granite code language model developed by IBM."""
+
     FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
 
     FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
@@ -151,11 +153,17 @@ def get_deepseek_r1_question_template_answer(question: CodeGenerationProblem):
     return prompt
 
 
-def get_watsonx_question_template_answer(question: CodeGenerationProblem):
-    prompt = "You will be given a question (problem specification) and will generate a correct Python program that matches the specification and passes all tests. You will NOT return anything except for the program.\n\n"
-    prompt += f"Question: {question.question_content}\n\n"
-    prompt += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n"
-    prompt += f"```python\n# YOUR CODE HERE\n```\n\n"
+def get_granite_question_template_answer(question: CodeGenerationProblem):
+    prompt = f"### Question:\n{question.question_content}\n\n"
+    if question.starter_code:
+        prompt += (
+            f"### Format: {PromptConstants.FORMATTING_MESSAGE_WITH_STARTER_CODE}\n"
+        )
+        prompt += f"```python\n{question.starter_code}\n```\n\n"
+    else:
+        prompt += f"### Format: {PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n"
+        prompt += "```python\n# YOUR CODE HERE\n```\n\n"
+    prompt += f"### Answer: (use the provided format with backticks)\n\n"
     return prompt
 
 
@@ -322,7 +330,17 @@ def format_prompt_generation(
         prompt = get_base_model_question_template_answer(question)
         return prompt
 
-    if LanguageModelStyle == LMStyle.Watsonx:
+    if LanguageModelStyle == LMStyle.WxGranite:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GRANITE}\n\n"
+        prompt += f"{get_granite_question_template_answer(question)}"
+        return prompt
+
+    if LanguageModelStyle == LMStyle.WxLLaMa:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n\n"
+        prompt += f"{get_generic_question_template_answer(question)}"
+        return prompt
+
+    if LanguageModelStyle == LMStyle.WxMistral:
         prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n\n"
         prompt += f"{get_generic_question_template_answer(question)}"
         return prompt

--- a/lcb_runner/prompts/code_generation.py
+++ b/lcb_runner/prompts/code_generation.py
@@ -46,8 +46,7 @@ def get_generic_question_template_answer(question: CodeGenerationProblem):
         prompt += f"```python\n{question.starter_code}\n```\n\n"
     else:
         prompt += f"### Format: {PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n"
-        prompt += "```python\n# YOUR CODE HERE\n```\n\n"
-    prompt += f"### Answer: (use the provided format with backticks)\n\n"
+    prompt += "### Answer:\nRespond ONLY with the final solution code inside a single code block like this:\n```python\n# YOUR CODE HERE\n```\n\n"
     return prompt
 
 

--- a/lcb_runner/prompts/code_generation.py
+++ b/lcb_runner/prompts/code_generation.py
@@ -29,7 +29,7 @@ class PromptConstants:
         "The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. "
         "The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think> <answer> answer here </answer>.<｜User｜>"
     )
-
+    SYSTEM_MESSAGE_GRANITE = """You are an intelligent AI programming assistant, utilizing a Granite code language model developed by IBM."""
     FORMATTING_MESSAGE_WITH_STARTER_CODE = "You will use the following starter code to write the solution to the problem and enclose your code within delimiters."
 
     FORMATTING_WITHOUT_STARTER_CODE = "Read the inputs from stdin solve the problem and write the answer to stdout (do not directly test on the sample inputs). Enclose your code within delimiters as follows. Ensure that when the python program runs, it reads the inputs, runs the algorithm and writes output to STDOUT."
@@ -148,6 +148,14 @@ def get_deepseek_r1_question_template_answer(question: CodeGenerationProblem):
         prompt += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n"
         prompt += f"```python\n# YOUR CODE HERE\n```\n\n"
     prompt += f"<｜Assistant｜>"
+    return prompt
+
+
+def get_watsonx_question_template_answer(question: CodeGenerationProblem):
+    prompt = "You will be given a question (problem specification) and will generate a correct Python program that matches the specification and passes all tests. You will NOT return anything except for the program.\n\n"
+    prompt += f"Question: {question.question_content}\n\n"
+    prompt += f"{PromptConstants.FORMATTING_WITHOUT_STARTER_CODE}\n"
+    prompt += f"```python\n# YOUR CODE HERE\n```\n\n"
     return prompt
 
 
@@ -312,6 +320,11 @@ def format_prompt_generation(
 
     if LanguageModelStyle == LMStyle.GenericBase:
         prompt = get_base_model_question_template_answer(question)
+        return prompt
+
+    if LanguageModelStyle == LMStyle.Watsonx:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n\n"
+        prompt += f"{get_generic_question_template_answer(question)}"
         return prompt
 
     raise NotImplementedError(

--- a/lcb_runner/prompts/self_repair.py
+++ b/lcb_runner/prompts/self_repair.py
@@ -46,14 +46,17 @@ def get_check_prompt(question: str, result, metadata):
         message = f"The above code is incorrect and got the following compilation error.\n{metadata['error']}"
     elif metadata["error_code"] == -2:
         # wrong answer
-        message = f"The above code is incorrect and got a wrong answer.\nInput: {metadata['inputs']}\nGenerated Output: {metadata['output']}\nExpected: {metadata['expected']}"
+        message = f"The above code is incorrect and got a wrong answer.\nInput: {metadata.get('inputs')}\nGenerated Output: {metadata.get('output')}\nExpected: {metadata.get('expected')}"
     elif metadata["error_code"] == -3:
         # time limit exceeded
-        message = f"The above code is incorrect and got time limit exceeded.\n{metadata['error']}\nInput: {metadata['inputs']}\nExpected: {metadata['expected']}"
+        message = f"The above code is incorrect and got time limit exceeded.\n{metadata.get('inputs')}\nInput: {metadata.get('inputs')}\nExpected: {metadata.get('expected')}"
         pass
     elif metadata["error_code"] == -4:
         # runtime error
-        message = f"The above code is incorrect and got a runtime error.\nInput: {metadata['inputs']}\nExpected: {metadata['expected']}\n{metadata['error']}"
+        message = f"The above code is incorrect and got a runtime error.\nInput: {metadata.get('inputs')}\nExpected: {metadata.get('expected')}\n{metadata.get('error')}"
+    elif metadata["error_code"] == -5:
+        # runtime error
+        message = f"The above code is incorrect and got a index error.\nInput: {metadata.get('inputs')}\nExpected: {metadata.get('expected')}\n{metadata.get('error')}"
     else:
         raise NotImplementedError(
             f"metadata['error_code'] = {metadata['error_code']} not implemented || {metadata=}"
@@ -140,6 +143,7 @@ def get_phind_question_template_answer(question: str, code, result, metadata):
     prompt += f"### Answer: (use the provided format with backticks)\n\n"
     return prompt
 
+
 def get_qwen_question_template_answer(question: str, code, result, metadata):
     from transformers import AutoTokenizer
 
@@ -171,6 +175,7 @@ def get_qwen_question_template_answer(question: str, code, result, metadata):
         padding=False,
     )
     return prompt
+
 
 def format_prompt_self_repair(
     question: str, LanguageModelStyle: LMStyle, code, result, metadata
@@ -242,7 +247,9 @@ def format_prompt_self_repair(
         chat_messages += [
             {
                 "role": "user",
-                "content": get_generic_question_template_answer(question, code, result, metadata),
+                "content": get_generic_question_template_answer(
+                    question, code, result, metadata
+                ),
             },
         ]
         return chat_messages
@@ -258,6 +265,15 @@ def format_prompt_self_repair(
         return prompt
     elif LanguageModelStyle == LMStyle.CodeLLaMaInstruct:
         prompt = f"[INST] <<SYS>>\n{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n<</SYS>>\n\n{get_cllama_question_template_answer(question, code, result,metadata)}\n[/INST]"
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxGranite:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n{get_generic_question_template_answer(question, code, result,metadata)}"
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxLLaMa:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n{get_generic_question_template_answer(question, code, result,metadata)}"
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxMistral:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n{get_generic_question_template_answer(question, code, result,metadata)}"
         return prompt
     elif LanguageModelStyle == LMStyle.MagiCoder:
         prompt = f"{PromptConstants.SYSTEM_MESSAGE_MAGIC}\n{get_magicoder_question_template_answer(question, code, result,metadata)}"
@@ -287,7 +303,9 @@ def format_prompt_self_repair(
         from transformers import AutoTokenizer
 
         tokenizer = AutoTokenizer.from_pretrained(
-            "abacusai/Dracarys-Llama-3.1-70B-Instruct", padding_side="right", use_fast=False
+            "abacusai/Dracarys-Llama-3.1-70B-Instruct",
+            padding_side="right",
+            use_fast=False,
         )
         return tokenizer.apply_chat_template(
             chat_messages,
@@ -298,7 +316,9 @@ def format_prompt_self_repair(
         )
     if LanguageModelStyle == LMStyle.Eurusx:
         prompt = "[INST] Write Python code to solve the task:\n"
-        prompt += f"{get_wizard_question_template_answer(question, code, result,metadata)}"
+        prompt += (
+            f"{get_wizard_question_template_answer(question, code, result,metadata)}"
+        )
         prompt += "[/INST]"
         return prompt
     else:

--- a/lcb_runner/prompts/test_output_prediction.py
+++ b/lcb_runner/prompts/test_output_prediction.py
@@ -132,7 +132,10 @@ def get_phind_question_template_answer(
     prompt += f"\n\n### Assistant"
     return prompt
 
-def get_qwen_question_template_answer(question: TestOutputPredictionProblem, testcase_input: str):
+
+def get_qwen_question_template_answer(
+    question: TestOutputPredictionProblem, testcase_input: str
+):
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(
@@ -155,6 +158,7 @@ def get_qwen_question_template_answer(question: TestOutputPredictionProblem, tes
         padding=False,
     )
     return prompt
+
 
 def format_prompt_test_output(
     question: TestOutputPredictionProblem, LanguageModelStyle: LMStyle
@@ -243,6 +247,24 @@ def format_prompt_test_output(
             f"{get_cllama_question_template_answer(question, testcase_input)}\n[/INST]"
         )
         return prompt
+    elif LanguageModelStyle == LMStyle.WxGranite:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_CHAT_GENERIC}\n"
+        prompt += (
+            f"{get_generic_question_template_test_completion(question, testcase_input)}"
+        )
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxLLaMa:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_CHAT_GENERIC}\n"
+        prompt += (
+            f"{get_generic_question_template_test_completion(question, testcase_input)}"
+        )
+        return prompt
+    elif LanguageModelStyle == LMStyle.WxMistral:
+        prompt = f"{PromptConstants.SYSTEM_MESSAGE_CHAT_GENERIC}\n"
+        prompt += (
+            f"{get_generic_question_template_test_completion(question, testcase_input)}"
+        )
+        return prompt
     elif LanguageModelStyle == LMStyle.MagiCoder:
         prompt = f"{PromptConstants.SYSTEM_MESSAGE_CHAT_GENERIC}\n"
         prompt += f"{get_magicoder_question_template_answer(question, testcase_input)}"
@@ -273,9 +295,7 @@ def format_prompt_test_output(
             },
         ]
         return chat_messages
-    elif (
-        LanguageModelStyle == LMStyle.DracarysQwen
-    ):
+    elif LanguageModelStyle == LMStyle.DracarysQwen:
         prompt = f"{get_qwen_question_template_answer(question, testcase_input)}"
         return prompt
     elif LanguageModelStyle == LMStyle.DracarysLlama:
@@ -296,7 +316,9 @@ def format_prompt_test_output(
         from transformers import AutoTokenizer
 
         tokenizer = AutoTokenizer.from_pretrained(
-            "abacusai/Dracarys-Llama-3.1-70B-Instruct", padding_side="right", use_fast=False
+            "abacusai/Dracarys-Llama-3.1-70B-Instruct",
+            padding_side="right",
+            use_fast=False,
         )
         return tokenizer.apply_chat_template(
             chat_messages,

--- a/lcb_runner/runner/main.py
+++ b/lcb_runner/runner/main.py
@@ -3,9 +3,9 @@ import json
 
 from lcb_runner.runner.parser import get_args
 from lcb_runner.utils.scenarios import Scenario
-from lcb_runner.lm_styles import LanguageModelStore
+from lcb_runner.lm_styles import LanguageModelStore, LMStyle
 from lcb_runner.runner.runner_utils import build_runner
-from lcb_runner.utils.path_utils import get_output_path
+from lcb_runner.utils.path_utils import get_output_path, save_summary_csv
 from lcb_runner.evaluation import extract_instance_results
 from lcb_runner.runner.scenario_router import (
     build_prompt_benchmark,
@@ -222,6 +222,13 @@ def main():
 
         with open(eval_all_file, "w") as f:
             json.dump(save_eval_results, f, indent=4)
+
+        if model.model_style in [LMStyle.WxGranite, LMStyle.WxLLaMa, LMStyle.WxMistral]:
+            params_file = output_path.replace(".json", "_params.csv")
+
+            save_summary_csv(
+                output_path=params_file, runner=runner, args=args, metrics=metrics
+            )
 
 
 if __name__ == "__main__":

--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -132,6 +132,7 @@ def get_args():
         help="End date for the contest to filter the evaluation file (format - YYYY-MM-DD)",
     )
     parser.add_argument("--seed", type=int, default=10, help="Random seed")
+    parser.add_argument("--env", type=str, default="hf", help="Environment of model")
 
     args = parser.parse_args()
 

--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -131,6 +131,7 @@ def get_args():
         default=None,
         help="End date for the contest to filter the evaluation file (format - YYYY-MM-DD)",
     )
+    parser.add_argument("--seed", type=int, default=10, help="Random seed")
 
     args = parser.parse_args()
 

--- a/lcb_runner/runner/runner_utils.py
+++ b/lcb_runner/runner/runner_utils.py
@@ -42,6 +42,10 @@ def build_runner(args, model: LanguageModel):
         from lcb_runner.runner.fireworks_runner import FireWorksRunner
 
         return FireWorksRunner(args, model)
+    if model.model_style == LMStyle.Watsonx:
+        from lcb_runner.runner.watsonx_runner import WatsonxRunner
+
+        return WatsonxRunner(args, model)
     elif model.model_style in []:
         raise NotImplementedError(
             f"Runner for language model style {model.model_style} not implemented yet"

--- a/lcb_runner/runner/runner_utils.py
+++ b/lcb_runner/runner/runner_utils.py
@@ -41,6 +41,12 @@ def build_runner(args, model: LanguageModel):
     if model.model_style in [LMStyle.WxGranite, LMStyle.WxLLaMa, LMStyle.WxMistral]:
         from lcb_runner.runner.watsonx_runner import WatsonxRunner
 
+        if args.env != "wx":
+            raise Exception(
+                f"{model.model_name} is not supported in the {args.env} environment. ",
+                "Only `wx` (WatsonX environment) is supported.",
+            )
+
         return WatsonxRunner(args, model)
 
     if "/fireworks/" in model.model_name:

--- a/lcb_runner/runner/runner_utils.py
+++ b/lcb_runner/runner/runner_utils.py
@@ -38,22 +38,15 @@ def build_runner(args, model: LanguageModel):
         from lcb_runner.runner.deepseek_runner import DeepSeekRunner
 
         return DeepSeekRunner(args, model)
+    if model.model_style in [LMStyle.WxGranite, LMStyle.WxLLaMa, LMStyle.WxMistral]:
+        from lcb_runner.runner.watsonx_runner import WatsonxRunner
+
+        return WatsonxRunner(args, model)
+
     if "/fireworks/" in model.model_name:
         from lcb_runner.runner.fireworks_runner import FireWorksRunner
 
         return FireWorksRunner(args, model)
-    if model.model_style == LMStyle.WxGranite:
-        from lcb_runner.runner.watsonx_runner import WatsonxRunner
-
-        return WatsonxRunner(args, model)
-    if model.model_style == LMStyle.WxLLaMa:
-        from lcb_runner.runner.watsonx_runner import WatsonxRunner
-
-        return WatsonxRunner(args, model)
-    if model.model_style == LMStyle.WxMistral:
-        from lcb_runner.runner.watsonx_runner import WatsonxRunner
-
-        return WatsonxRunner(args, model)
     elif model.model_style in []:
         raise NotImplementedError(
             f"Runner for language model style {model.model_style} not implemented yet"

--- a/lcb_runner/runner/runner_utils.py
+++ b/lcb_runner/runner/runner_utils.py
@@ -42,7 +42,15 @@ def build_runner(args, model: LanguageModel):
         from lcb_runner.runner.fireworks_runner import FireWorksRunner
 
         return FireWorksRunner(args, model)
-    if model.model_style == LMStyle.Watsonx:
+    if model.model_style == LMStyle.WxGranite:
+        from lcb_runner.runner.watsonx_runner import WatsonxRunner
+
+        return WatsonxRunner(args, model)
+    if model.model_style == LMStyle.WxLLaMa:
+        from lcb_runner.runner.watsonx_runner import WatsonxRunner
+
+        return WatsonxRunner(args, model)
+    if model.model_style == LMStyle.WxMistral:
         from lcb_runner.runner.watsonx_runner import WatsonxRunner
 
         return WatsonxRunner(args, model)

--- a/lcb_runner/runner/watsonx_runner.py
+++ b/lcb_runner/runner/watsonx_runner.py
@@ -1,5 +1,6 @@
 import os
 from time import sleep
+import logging
 
 try:
     from ibm_watsonx_ai import APIClient, Credentials
@@ -13,14 +14,6 @@ from lcb_runner.lm_styles import LanguageModel
 
 class WatsonxRunner(BaseRunner):
 
-    client = APIClient(
-        credentials=Credentials(
-            url=os.getenv("WML_URL"), api_key=os.getenv("WML_APIKEY")
-        ),
-        space_id=os.getenv("WML_SPACE_ID"),
-        project_id=os.getenv("WML_PROJECT_ID"),
-    )
-
     def __init__(self, args, model: LanguageModel):
         super().__init__(args, model)
         self.generate_params: dict[str | str] = {
@@ -29,12 +22,74 @@ class WatsonxRunner(BaseRunner):
             "top_p": args.top_p,
             "random_seed": args.seed,
         }
+        creds = self._read_wx_credentials()
+
+        self.client = APIClient(
+            credentials=creds,
+            space_id=creds.get("space_id"),
+            project_id=creds.get("project_id"),
+        )
 
         self.model_inference = ModelInference(
             model_id=args.model,
-            api_client=WatsonxRunner.client,
+            api_client=self.client,
             params=self.generate_params,
         )
+
+    @staticmethod
+    def _read_wx_credentials() -> dict[str, str]:
+        credentials = {}
+
+        url = os.environ.get("WX_URL")
+        if not url:
+            raise EnvironmentError(
+                "You need to specify the URL address by setting the env "
+                "variable 'WX_URL', if you want to run watsonx.ai inference."
+            )
+        credentials["url"] = url
+
+        project_id = os.environ.get("WX_PROJECT_ID")
+        space_id = os.environ.get("WX_SPACE_ID")
+        if project_id and space_id:
+            logging.warning(
+                "Both the project ID and the space ID were specified. "
+                "The class 'WxInference' will access the project by default."
+            )
+            credentials["project_id"] = project_id
+        elif project_id:
+            credentials["project_id"] = project_id
+        elif space_id:
+            credentials["space_id"] = space_id
+        else:
+            raise EnvironmentError(
+                "You need to specify the project ID or the space id by setting the "
+                "appropriate env variable (either 'WX_PROJECT_ID' or 'WX_SPACE_ID'), "
+                "if you want to run watsonx.ai inference."
+            )
+
+        apikey = os.environ.get("WX_APIKEY")
+        username = os.environ.get("WX_USERNAME")
+        password = os.environ.get("WX_PASSWORD")
+        if apikey and username and password:
+            logging.warning(
+                "All of API key, username and password were specified. "
+                "The class 'WxInference' will use the API key for authorization "
+                "by default."
+            )
+            credentials["apikey"] = apikey
+        elif apikey:
+            credentials["apikey"] = apikey
+        elif username and password:
+            credentials["username"] = username
+            credentials["password"] = password
+        else:
+            raise EnvironmentError(
+                "You need to specify either the API key, or both the username and "
+                "password by setting appropriate env variable ('WX_APIKEY', 'WX_USERNAME', "
+                "'WX_PASSWORD'), if you want to run watsonx.ai inference."
+            )
+
+        return credentials
 
     def _run_single(self, prompt: str | list[dict[str, str]]) -> list[str]:
         assert isinstance(prompt, str) or isinstance(prompt, list)

--- a/lcb_runner/runner/watsonx_runner.py
+++ b/lcb_runner/runner/watsonx_runner.py
@@ -1,0 +1,64 @@
+import os
+from time import sleep
+
+try:
+    from ibm_watsonx_ai import APIClient, Credentials
+    from ibm_watsonx_ai.foundation_models import ModelInference
+except ImportError as e:
+    pass
+
+from lcb_runner.runner.base_runner import BaseRunner
+from lcb_runner.lm_styles import LanguageModel
+
+
+class WatsonxRunner(BaseRunner):
+
+    client = APIClient(
+        credentials=Credentials(
+            url=os.getenv("WML_URL"), api_key=os.getenv("WML_APIKEY")
+        ),
+        space_id=os.getenv("WML_SPACE_ID"),
+        project_id=os.getenv("WML_PROJECT_ID"),
+    )
+
+    def __init__(self, args, model: LanguageModel):
+        super().__init__(args, model)
+        self.generate_params: dict[str | str] = {
+            "temperature": args.temperature,
+            "max_new_tokens": args.max_tokens,
+            "top_p": args.top_p,
+            "random_seed": 10,
+        }
+
+        self.model_inference = ModelInference(
+            model_id=args.model,
+            api_client=WatsonxRunner.client,
+            params=self.generate_params,
+        )
+
+    def _run_single(self, prompt: str | list[dict[str, str]]) -> list[str]:
+        assert isinstance(prompt, str) or isinstance(prompt, list)
+
+        def __run_single(counter) -> list[str]:
+            try:
+                prompts = [prompt] * self.args.n
+                outputs = self.model_inference.generate(prompt=prompts)
+                if isinstance(outputs, list):
+                    return [val["results"][0]["generated_text"] for val in outputs]
+
+                return [outputs["results"][0]["generated_text"]]
+            except Exception as e:
+                sleep_time = 20 * (11 - counter)
+                print("Exception: ", repr(e), f"Sleeping for {sleep_time} seconds...")
+                sleep(sleep_time)
+                counter = counter - 1
+                if counter == 0:
+                    print(f"Failed to run model for {prompt}!")
+                    print("Exception: ", repr(e))
+                    raise e
+                return __run_single(counter)
+
+        try:
+            return __run_single(10)
+        except Exception as e:
+            raise e

--- a/lcb_runner/runner/watsonx_runner.py
+++ b/lcb_runner/runner/watsonx_runner.py
@@ -27,7 +27,7 @@ class WatsonxRunner(BaseRunner):
             "temperature": args.temperature,
             "max_new_tokens": args.max_tokens,
             "top_p": args.top_p,
-            "random_seed": 10,
+            "random_seed": args.seed,
         }
 
         self.model_inference = ModelInference(

--- a/lcb_runner/utils/extraction_utils.py
+++ b/lcb_runner/utils/extraction_utils.py
@@ -1,14 +1,27 @@
 from lcb_runner.lm_styles import LMStyle
+import re
 
 
 def extract_code(model_output: str, lmstyle: LMStyle):
     outputlines = model_output.split("\n")
+
     if lmstyle == LMStyle.CodeLLaMaInstruct:
         indexlines = [i for i, line in enumerate(outputlines) if "PYTHON]" in line]
         if len(indexlines) < 2:
             indexlines = [i for i, line in enumerate(outputlines) if "```" in line]
     elif lmstyle == LMStyle.GenericBase:
         return model_output.strip()
+    elif lmstyle in [LMStyle.WxLLaMa, LMStyle.WxGranite, LMStyle.WxMistral]:
+
+        matches = re.findall(r"```python\s*\n(.*?)```", model_output, re.DOTALL)
+        if not matches:
+            matches = re.findall(r"```\s*\n(.*?)```", model_output, re.DOTALL)
+
+        for match in matches:
+            stripped_string = match.strip()
+            if stripped_string:
+                return stripped_string
+        return ""
     else:
         indexlines = [i for i, line in enumerate(outputlines) if "```" in line]
         if len(indexlines) < 2:

--- a/lcb_runner/utils/path_utils.py
+++ b/lcb_runner/utils/path_utils.py
@@ -12,7 +12,7 @@ def ensure_dir(path: str, is_file=True):
     return
 
 
-def get_cache_path(model_repr:str, args) -> str:
+def get_cache_path(model_repr: str, args) -> str:
     scenario: Scenario = args.scenario
     n = args.n
     temperature = args.temperature
@@ -21,7 +21,7 @@ def get_cache_path(model_repr:str, args) -> str:
     return path
 
 
-def get_output_path(model_repr:str, args) -> str:
+def get_output_path(model_repr: str, args) -> str:
     scenario: Scenario = args.scenario
     n = args.n
     temperature = args.temperature
@@ -31,10 +31,44 @@ def get_output_path(model_repr:str, args) -> str:
     return path
 
 
-def get_eval_all_output_path(model_repr:str, args) -> str:
+def get_eval_all_output_path(model_repr: str, args) -> str:
     scenario: Scenario = args.scenario
     n = args.n
     temperature = args.temperature
     cot_suffix = "_cot" if args.cot_code_execution else ""
     path = f"output/{model_repr}/{scenario}_{n}_{temperature}{cot_suffix}_eval_all.json"
     return path
+
+
+def save_summary_csv(output_path, runner, args, metrics=None):
+    import pandas as pd
+
+    pass_val = metrics[0].get("pass@1") if metrics else None
+    params = runner.generate_params
+    params["n_samples"] = args.n
+    if args.cot_code_execution:
+        params["cot_code_execution"] = True
+
+    if args.scenario == Scenario.selfrepair:
+        task = "code-fixing"
+    else:
+        task = "code-generation"
+
+    data = {
+        "dataset": [args.scenario.value],
+        "language": ["python"],
+        "model": [args.model],
+        "framework": ["LiveCodeBench"],
+        "score_name": ["pass@1"],
+        "score": [pass_val],
+        "task": [task],
+        "generation_parameters": [params],
+        "all_scores": [{"pass@1": pass_val}],
+        "inference_env": ["wml"],
+        "code_execution_env": ["wxai-code-exec"],
+        "is_from_academic_paper": [False],
+    }
+
+    df = pd.DataFrame(data)
+
+    df.to_csv(output_path, index=False)


### PR DESCRIPTION
Command to run benchmark **codegeneration** (15 problems (due to debug mode) x  1  sample (param _n_)
```bash
python -m lcb_runner.runner.main --model "ibm/granite-20b-code-instruct" --scenario codegeneration --evaluate --debug --n 1
```

Remote code execution will be added soon.

![Screenshot 2025-03-14 at 13 15 55](https://github.com/user-attachments/assets/f0e80968-6eec-403c-92f2-10752401a8e6)
